### PR TITLE
Pluralize values and omit seconds

### DIFF
--- a/expenditures/app.py
+++ b/expenditures/app.py
@@ -166,11 +166,11 @@ def generate_response (rand_fact):
     prevNum = False
     timecomponents = []
     if days:
-        timecomponents.append("%d %s" % days % plural("day", days))
+        timecomponents.append("%d %s" % (days, plural("day", days)))
     if hours:
-        timecomponents.append("%d %s" % hours % plural("hr", hours))
+        timecomponents.append("%d%s" % (hours, plural("hr", hours)))
     if mins:
-        timecomponents.append("%d %s" % mins % plural("min", mins))
+        timecomponents.append("%d%s" % (mins, plural("min", mins)))
 
     text += ", ".join(timecomponents)
 

--- a/expenditures/app.py
+++ b/expenditures/app.py
@@ -166,13 +166,12 @@ def generate_response (rand_fact):
     prevNum = False
     timecomponents = []
     if days:
-        timecomponents.append("%d days" % days)
+        timecomponents.append("%d %s" % days % plural("day", days))
     if hours:
-        timecomponents.append("%dhrs" % hours)
+        timecomponents.append("%d %s" % hours % plural("hr", hours))
     if mins:
-        timecomponents.append("%dmins" % mins)
-    if secs:
-        timecomponents.append("%ds" % secs)
+        timecomponents.append("%d %s" % mins % plural("min", mins))
+
     text += ", ".join(timecomponents)
 
     text += " [%s]" % rand_fact['source']


### PR DESCRIPTION
This PR makes a few small improvements to the text:

* omit seconds
* use the characters saved from that to consistently put a space between # and time unit
* use the existing `plural` method to pluralize days/hours/minutes (when appropriate)

Note: I'm not a Python developer and I haven't been able to figure out I'm not sure how to test this locally, so someone should definitely test this out.